### PR TITLE
Add topbar and reuse sidebar component for layout

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -8,7 +8,7 @@ const linkStyle = ({isActive}) => ({
 
 export default function Nav() {
   return (
-    <aside style={{borderRight:'1px solid #eee', padding:'18px 10px'}}>
+    <aside style={{width:180, borderRight:'1px solid #eee', padding:'18px 10px'}}>
       <h3 style={{margin:'0 8px 12px'}}>VPN Admin</h3>
       <NavLink to="/dashboard" style={linkStyle}>Dashboard</NavLink>
       <NavLink to="/users" style={linkStyle}>Users</NavLink>

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Topbar() {
+  return (
+    <header style={{ borderBottom: '1px solid #eee', padding: '12px 16px', background: '#f8fafc' }}>
+      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>VPN Admin Panel</h1>
+    </header>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Routes, Route, NavLink, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Dashboard from "./pages/Dashboard.jsx";
 import Users from "./pages/Users.jsx";
 import Sessions from "./pages/Sessions.jsx";
 import Tools from "./pages/Tools.jsx";
+import Nav from "./components/Nav.jsx";
+import Topbar from "./components/Topbar.jsx";
 
 function ErrorBoundary({ children }) {
   const [err, setErr] = React.useState(null);
@@ -39,16 +41,11 @@ function BoundarySetter({ children, onError }) {
 function Layout({ children }) {
   return (
     <div style={{ display: "flex", minHeight: "100vh", fontFamily: "system-ui, Arial" }}>
-      <aside style={{ width: 180, borderRight: "1px solid #eee", padding: 16 }}>
-        <h3 style={{ marginTop: 0 }}>VPN Admin</h3>
-        <nav style={{ display: "grid", gap: 8 }}>
-          <NavLink to="/dashboard">Dashboard</NavLink>
-          <NavLink to="/users">Users</NavLink>
-          <NavLink to="/sessions">Sessions</NavLink>
-          <NavLink to="/tools">Tools</NavLink>
-        </nav>
-      </aside>
-      <main style={{ flex: 1, padding: 24 }}>{children}</main>
+      <Nav />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Topbar />
+        <main style={{ flex: 1, padding: 24 }}>{children}</main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable Topbar component for page header
- reuse Nav component for sidebar and wire up routes in layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b09cdb50b8832ebaf26bc1446099e5