### PR TITLE
Add basic styling and dashboard metrics

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,19 +1,16 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
-const linkStyle = ({isActive}) => ({
-  display:'block', padding:'10px 12px', borderRadius:10, margin:'6px 8px',
-  textDecoration:'none', color:isActive?'#fff':'#333', background:isActive?'#3b82f6':'transparent'
-});
-
 export default function Nav() {
+  const linkClass = ({ isActive }) =>
+    isActive ? 'nav-link active' : 'nav-link';
   return (
-    <aside style={{width:180, borderRight:'1px solid #eee', padding:'18px 10px'}}>
-      <h3 style={{margin:'0 8px 12px'}}>VPN Admin</h3>
-      <NavLink to="/dashboard" style={linkStyle}>Dashboard</NavLink>
-      <NavLink to="/users" style={linkStyle}>Users</NavLink>
-      <NavLink to="/sessions" style={linkStyle}>Sessions</NavLink>
-      <NavLink to="/tools" style={linkStyle}>Tools</NavLink>
+    <aside className="sidebar">
+      <div className="brand">VPN Admin</div>
+      <NavLink to="/dashboard" className={linkClass}>Dashboard</NavLink>
+      <NavLink to="/users" className={linkClass}>Users</NavLink>
+      <NavLink to="/sessions" className={linkClass}>Sessions</NavLink>
+      <NavLink to="/tools" className={linkClass}>Tools</NavLink>
     </aside>
   );
 }

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -2,8 +2,8 @@ import React from "react";
 
 export default function Topbar() {
   return (
-    <header style={{ borderBottom: '1px solid #eee', padding: '12px 16px', background: '#f8fafc' }}>
-      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>VPN Admin Panel</h1>
+    <header className="topbar">
+      <h1>VPN Admin Panel</h1>
     </header>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import "./styles.css";
 import Dashboard from "./pages/Dashboard.jsx";
 import Users from "./pages/Users.jsx";
 import Sessions from "./pages/Sessions.jsx";
@@ -40,11 +41,11 @@ function BoundarySetter({ children, onError }) {
 
 function Layout({ children }) {
   return (
-    <div style={{ display: "flex", minHeight: "100vh", fontFamily: "system-ui, Arial" }}>
+    <div style={{ display: "flex", minHeight: "100vh" }}>
       <Nav />
       <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
         <Topbar />
-        <main style={{ flex: 1, padding: 24 }}>{children}</main>
+        <main>{children}</main>
       </div>
     </div>
   );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { getHealth } from "../lib/api";
 
+function metricValue(val, suffix = "") {
+  if (val === undefined || val === null) return "-";
+  return `${val}${suffix}`;
+}
+
 export default function Dashboard() {
   const [data, setData] = React.useState(null);
   const [err, setErr] = React.useState("");
@@ -10,22 +15,41 @@ export default function Dashboard() {
     getHealth()
       .then((d) => alive && setData(d))
       .catch((e) => alive && setErr(String(e.message || e)));
-    return () => { alive = false; };
+    return () => {
+      alive = false;
+    };
   }, []);
 
   return (
     <div>
-      <h2>Dashboard</h2>
-      {err && (
-        <div style={{ padding: 12, background: "#ffe8e8", border: "1px solid #f5bcbc", marginBottom: 12 }}>
-          <strong>Error:</strong> {err}
-        </div>
-      )}
+      <h2 style={{ marginBottom: 16 }}>Dashboard</h2>
+      {err && <div className="alert">Error: {err}</div>}
       {!data && !err && <div>Loading...</div>}
       {data && (
-        <pre style={{ background: "#f6f8fa", padding: 16, borderRadius: 8 }}>
-{JSON.stringify(data, null, 2)}
-        </pre>
+        <>
+          <div className="grid grid-4" style={{ marginBottom: 24 }}>
+            <div className="card">
+              <div className="card-title">CPU Usage</div>
+              <div className="card-value">{metricValue(data.cpuUsage ?? data.cpu, "%")}</div>
+            </div>
+            <div className="card">
+              <div className="card-title">Memory Usage</div>
+              <div className="card-value">{metricValue(data.memoryUsage ?? data.memory, "%")}</div>
+            </div>
+            <div className="card">
+              <div className="card-title">Disk Usage</div>
+              <div className="card-value">{metricValue(data.diskUsage ?? data.disk, "%")}</div>
+            </div>
+            <div className="card">
+              <div className="card-title">Uptime</div>
+              <div className="card-value">{metricValue(data.uptime)}</div>
+            </div>
+          </div>
+          <div className="card">
+            <div className="card-title">Raw Metrics</div>
+            <pre style={{ margin: 0 }}>{JSON.stringify(data, null, 2)}</pre>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/pages/Users.jsx
+++ b/src/pages/Users.jsx
@@ -13,69 +13,124 @@ export default function Users() {
     setUsers(d.users || []);
   }
 
-  React.useEffect(() => { refresh().catch(e => setMsg(String(e))); }, []);
+  React.useEffect(() => {
+    refresh().catch((e) => setMsg(String(e)));
+  }, []);
+
+  const online = users.filter((u) => u.online || u.status === "online").length;
+  const offline = users.length - online;
 
   return (
     <div>
-      <h2>Users</h2>
+      <h2 style={{ marginBottom: 16 }}>VPN Users</h2>
 
-      {msg && <div style={{ padding: 8, background: "#fff3cd", border: "1px solid #ffeeba" }}>{msg}</div>}
+      {msg && <div className="alert">{msg}</div>}
 
-      <div style={{ display:"flex", gap:8, marginBottom:12 }}>
-        <input value={email} onChange={e=>setEmail(e.target.value)} placeholder="email user" style={{ padding:8 }} />
-        <button onClick={async ()=>{
-          if(!email) return setMsg("isi email dulu");
-          try {
-            const r = await createUser(email);
-            setMsg(r.message || "created");
-            await refresh();
-          } catch(e) { setMsg(String(e.message||e)); }
-        }}>Create</button>
+      <div className="grid grid-4" style={{ marginBottom: 24 }}>
+        <div className="card">
+          <div className="card-title">Total Users</div>
+          <div className="card-value">{users.length}</div>
+        </div>
+        <div className="card">
+          <div className="card-title">Online Now</div>
+          <div className="card-value">{online}</div>
+        </div>
+        <div className="card">
+          <div className="card-title">Offline</div>
+          <div className="card-value">{offline}</div>
+        </div>
+      </div>
 
-        <input value={pass} onChange={e=>setPass(e.target.value)} placeholder="new password" style={{ padding:8 }} />
-        <button onClick={async ()=>{
-          if(!email || !pass) return setMsg("isi email & password");
-          try {
-            const r = await setPassword(email, pass);
-            setMsg(r.message || "password updated");
-          } catch(e) { setMsg(String(e.message||e)); }
-        }}>Set Password</button>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 16 }}>
+        <input
+          className="input"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="user email"
+        />
+        <button
+          className="button"
+          onClick={async () => {
+            if (!email) return setMsg("isi email dulu");
+            try {
+              const r = await createUser(email);
+              setMsg(r.message || "created");
+              await refresh();
+            } catch (e) {
+              setMsg(String(e.message || e));
+            }
+          }}
+        >
+          Create
+        </button>
 
-        <button onClick={async ()=>{
-          if(!email) return setMsg("isi email dulu");
-          try {
-            const r = await delUser(email);
-            setMsg(r.message || "deleted");
-            await refresh();
-          } catch(e) { setMsg(String(e.message||e)); }
-        }}>Delete</button>
+        <input
+          className="input"
+          value={pass}
+          onChange={(e) => setPass(e.target.value)}
+          placeholder="new password"
+        />
+        <button
+          className="button"
+          onClick={async () => {
+            if (!email || !pass) return setMsg("isi email & password");
+            try {
+              const r = await setPassword(email, pass);
+              setMsg(r.message || "password updated");
+            } catch (e) {
+              setMsg(String(e.message || e));
+            }
+          }}
+        >
+          Set Password
+        </button>
 
-        <a href={downloadOvpn(email)} style={{ padding:8, border:"1px solid #ddd", borderRadius:6, textDecoration:"none" }}>
+        <button
+          className="button secondary"
+          onClick={async () => {
+            if (!email) return setMsg("isi email dulu");
+            try {
+              const r = await delUser(email);
+              setMsg(r.message || "deleted");
+              await refresh();
+            } catch (e) {
+              setMsg(String(e.message || e));
+            }
+          }}
+        >
+          Delete
+        </button>
+
+        <a
+          className="button"
+          style={{ textDecoration: "none" }}
+          href={downloadOvpn(email)}
+        >
           Download OVPN
         </a>
       </div>
 
-      <table style={{ width:"100%", borderCollapse:"collapse" }}>
+      <table className="table">
         <thead>
           <tr>
-            <th style={td}>User</th>
-            <th style={td}>Group</th>
+            <th>User</th>
+            <th>Group</th>
           </tr>
         </thead>
         <tbody>
-          {users.map((u, i)=>(
+          {users.map((u, i) => (
             <tr key={i}>
-              <td style={td}>{u.name}</td>
-              <td style={td}>{u.group || "-"}</td>
+              <td>{u.name}</td>
+              <td>{u.group || "-"}</td>
             </tr>
           ))}
           {!users.length && (
-            <tr><td style={td} colSpan={2}>No users</td></tr>
+            <tr>
+              <td colSpan={2}>No users</td>
+            </tr>
           )}
         </tbody>
       </table>
     </div>
   );
 }
-
-const td = { border:"1px solid #eee", padding:"8px 10px", textAlign:"left" };

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,137 @@
+:root {
+  --bg: #f1f5f9;
+  --sidebar-bg: #ffffff;
+  --border-color: #e2e8f0;
+  --card-bg: #ffffff;
+  --primary: #3b82f6;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: #1e293b;
+  font-family: system-ui, Arial, sans-serif;
+}
+
+.sidebar {
+  width: 200px;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border-color);
+  padding: 18px 10px;
+}
+
+.sidebar .brand {
+  margin: 0 8px 20px;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.nav-link {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 8px;
+  margin: 6px 8px;
+  text-decoration: none;
+  color: #334155;
+}
+
+.nav-link.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+header.topbar {
+  background: #ffffff;
+  border-bottom: 1px solid var(--border-color);
+  padding: 12px 16px;
+}
+
+header.topbar h1 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+main {
+  flex: 1;
+  padding: 24px;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.grid-4 {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+}
+
+.card-title {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.card-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.table th,
+.table td {
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.table th {
+  background: #f8fafc;
+  font-weight: 600;
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.input {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.button {
+  padding: 8px 12px;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.button.secondary {
+  background: #64748b;
+}
+
+.alert {
+  padding: 8px;
+  margin-bottom: 16px;
+  border-radius: 6px;
+  background: #fff3cd;
+  border: 1px solid #ffeeba;
+}


### PR DESCRIPTION
## Summary
- Add global stylesheet for sidebar, cards, tables and buttons
- Rework navigation and top bar to use new styles
- Show CPU, memory, disk and uptime metrics with cards on dashboard
- Improve Users page with stat cards and styled table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b18e966f80832e9befcd3ea4b7a3cf