### PR TITLE
Fix duplicate user creation route with list endpoint

### DIFF
--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -24,17 +24,15 @@ router.post("/create", async (req, res) => {
 });
 
 // LIST users
-router.post("/create", async (req, res) => {
-  const { email } = req.body || {};
-  if (!email) return res.status(400).json({ success: false, error: "Email required" });
-  const username = usernameFromEmail(email);
-  const password = "asaku123";
+router.get("/list", async (_req, res) => {
   try {
-    await vpnService.createUser(username, password);
-    res.json({ success: true, message: `User ${username} created`, password });
+    const users = await vpnService.listUsers();
+    res.json({ success: true, users });
   } catch (err) {
-    console.error("createUser error:", err);
-    res.status(503).json({ success: false, error: "SoftEther CLI busy, try again." });
+    console.error("listUsers error:", err);
+    res
+      .status(503)
+      .json({ success: false, error: "SoftEther CLI busy, try again." });
   }
 });
 


### PR DESCRIPTION
## Summary
- replace duplicated `/create` handler with `/list` GET route for listing users
- ensure all user routes use unique paths and handlers

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd api && npm test)` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1e0e27c10832ead3dba4936e0a732