### PR TITLE
fix: call metrics endpoint for health check

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -13,7 +13,7 @@ async function req(path, opts={}) {
 
 export const Api = {
   // metrics
-  health:      () => req('/metrics/health'),
+  health:      () => req('/metrics'),
 
   // users
   usersList:   () => req('/vpn/list'),


### PR DESCRIPTION
## Summary
- Query `/metrics` in `Api.health`
- Ensure dashboard uses `getHealth` from library API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e4857330832e8b8dc69498314595