### PR TITLE
feat: add cpu and memory usage metrics

### DIFF
--- a/api/routes/metrics.js
+++ b/api/routes/metrics.js
@@ -57,14 +57,22 @@ function getDiskUsage(cb) {
 router.get("/", (req, res) => {
   const systemUptimeSec = getSystemUptimeSec();
   const processUptimeSec = Math.floor(process.uptime());
+  const loadavg = os.loadavg();
+  const freemem = os.freemem();
+  const totalmem = os.totalmem();
+  const cpus = os.cpus().length;
+  const cpuUsage = cpus ? (loadavg[0] / cpus) * 100 : 0;
+  const memoryUsage = totalmem ? (1 - freemem / totalmem) * 100 : 0;
   const base = {
     uptime: processUptimeSec,
     processUptimeSec,
     systemUptimeSec,
-    loadavg: os.loadavg(),
-    freemem: os.freemem(),
-    totalmem: os.totalmem(),
-    cpus: os.cpus().length,
+    loadavg,
+    freemem,
+    totalmem,
+    cpus,
+    cpuUsage,
+    memoryUsage,
     timestamp: new Date()
   };
   const net = getNetBytes();

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -30,11 +30,11 @@ export default function Dashboard() {
           <div className="grid grid-4" style={{ marginBottom: 24 }}>
             <div className="card">
               <div className="card-title">CPU Usage</div>
-              <div className="card-value">{metricValue(data.cpuUsage ?? data.cpu, "%")}</div>
+              <div className="card-value">{metricValue(data.cpuUsage, "%")}</div>
             </div>
             <div className="card">
               <div className="card-title">Memory Usage</div>
-              <div className="card-value">{metricValue(data.memoryUsage ?? data.memory, "%")}</div>
+              <div className="card-value">{metricValue(data.memoryUsage, "%")}</div>
             </div>
             <div className="card">
               <div className="card-title">Disk Usage</div>


### PR DESCRIPTION
## Summary
- compute CPU and memory usage percentages in metrics route
- display `cpuUsage` and `memoryUsage` on dashboard without fallbacks

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `api` *(fails: Missing script)*
- `npm run build`
- `node - <<'NODE' const os=require('os'); const cpus=os.cpus().length; const cpuUsage=cpus?(os.loadavg()[0]/cpus)*100:0; const memoryUsage=(1-os.freemem()/os.totalmem())*100; console.log({cpuUsage,memoryUsage}); NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b1e715b66c832ea47cf0291b378fc4