### PR TITLE
Document VITE_API_BASE usage and add API reachability warning

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VITE_API_BASE=/api
+VITE_API_BASE=http://localhost:3000/api
 VITE_API_KEY=17AgustusTahun1945ItulahHariKemerdekaanKitaHariMerdekaNusaDanBangsa

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,2 @@
-VITE_API_BASE=/api
+VITE_API_BASE=https://vpn.example.com/api
 VITE_API_KEY=17AgustusTahun1945ItulahHariKemerdekaanKitaHariMerdekaNusaDanBangsa
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# VPN Admin Panel
+
+A simple admin interface for managing VPN users.
+
+## Configuration
+
+The app reads its configuration from environment variables. `VITE_API_BASE` must point to the root of the server API. Use an absolute URL (including protocol and host) when the API is served from a different origin.
+
+Sample configuration files are provided:
+
+- `.env.development` – defaults to a local API (`http://localhost:3000/api`).
+- `.env.production` – example configuration for production (`https://vpn.example.com/api`).
+
+Copy the appropriate file to `.env` or adjust the variables for your environment.
+
+## Scripts
+
+- `npm run dev` – start the development server
+- `npm run build` – build for production
+- `npm run preview` – preview the production build

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -3,6 +3,13 @@
 const API_BASE = import.meta.env.VITE_API_BASE || '/api';
 const API_KEY  = import.meta.env.VITE_API_KEY || '17AgustusTahun1945ItulahHariKemerdekaanKitaHariMerdekaNusaDanBangsa';
 
+// Warn early if the API cannot be reached – helps detect misconfigured VITE_API_BASE.
+if (typeof window !== 'undefined') {
+  fetch(API_BASE + '/metrics').catch(err => {
+    console.warn(`Unable to reach API at ${API_BASE}; check VITE_API_BASE`, err);
+  });
+}
+
 async function api(path, opts = {}) {
   const url = API_BASE + path;
   const init = {


### PR DESCRIPTION
## Summary
- document that `VITE_API_BASE` must point to the API root and provide sample env files
- warn at runtime if the API `/metrics` endpoint is unreachable

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b1e8175fd4832eb3c1540c02e07df8